### PR TITLE
Delete discount

### DIFF
--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -24,6 +24,11 @@ class MerchantDiscountsController < ApplicationController
         end
     end
 
+    def destroy
+      @discount = BulkDiscount.delete(params[:id])
+      redirect_to merchant_discounts_path(params[:merchant_id])
+    end
+
     private
     def discount_params
       params.permit(:quantity, :discount)

--- a/app/views/merchant_discounts/index.html.erb
+++ b/app/views/merchant_discounts/index.html.erb
@@ -10,6 +10,7 @@
 
 <div id='discount-list'>
     <% @merchant.bulk_discounts.each do |discount| %>
-        <%= link_to("Threshold Quantity: #{discount.quantity}, Discount: #{discount.discount}%", merchant_discount_path(@merchant, discount)) %><br>
+        <%= link_to("Threshold Quantity: #{discount.quantity}, Discount: #{discount.discount}%", merchant_discount_path(@merchant, discount)) %>
+        <%= link_to("Delete Discount", merchant_discount_path(@merchant, discount), method: :delete) %><br>
     <% end %>
 </div>

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Merchant Discounts Index page' do
         expect(current_path).to eq(new_merchant_discount_path(merchant_1))
     end
 
-    it 'has a link to create a delete each discount' do
+    it 'has a link to delete a discount' do
         merchant_1 = Merchant.create!(name: 'Mike Dao')
         discount_1 = BulkDiscount.create!(quantity: 10, discount: 20, merchant_id: merchant_1.id)
         discount_2 = BulkDiscount.create!(quantity: 15, discount: 30, merchant_id: merchant_1.id)
@@ -46,7 +46,9 @@ RSpec.describe 'Merchant Discounts Index page' do
         visit "/merchants/#{merchant_1.id}/discounts"
 
         within "#discount-list" do
-            expect(page).to have_link("delete", count: 2)
+            expect(page).to have_link("Delete Discount", count: 2)
+            first(:link, "Delete Discount").click
+            expect(page).to have_link("Delete Discount", count: 1)
         end
     end
 end

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -37,4 +37,16 @@ RSpec.describe 'Merchant Discounts Index page' do
 
         expect(current_path).to eq(new_merchant_discount_path(merchant_1))
     end
+
+    it 'has a link to create a delete each discount' do
+        merchant_1 = Merchant.create!(name: 'Mike Dao')
+        discount_1 = BulkDiscount.create!(quantity: 10, discount: 20, merchant_id: merchant_1.id)
+        discount_2 = BulkDiscount.create!(quantity: 15, discount: 30, merchant_id: merchant_1.id)
+
+        visit "/merchants/#{merchant_1.id}/discounts"
+
+        within "#discount-list" do
+            expect(page).to have_link("delete", count: 2)
+        end
+    end
 end


### PR DESCRIPTION
Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed